### PR TITLE
Ensure that a user's PATH variable is available when a costum env is used in server config

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,1 +1,2 @@
 node_modules
+.vscode/

--- a/src/mcp.js
+++ b/src/mcp.js
@@ -157,6 +157,9 @@ export async function runWithConfig(configPath) {
   }
   const server = await pickServer(config);
   const serverConfig = config.mcpServers[server];
+  if (serverConfig.env) {
+    serverConfig.env = { ...serverConfig.env, PATH: process.env.PATH };
+  }
   const transport = new StdioClientTransport(serverConfig);
   await connectServer(transport);
 }


### PR DESCRIPTION
This PR fixes a problem where a user's PATH variable is not available to a server when a custom `env` is specified in that server's config. 

Addresses #6 