### PR TITLE
Add non-interactive mode support

### DIFF
--- a/README.md
+++ b/README.md
@@ -53,6 +53,32 @@ npx @wong2/mcp-cli --url http://localhost:8000/mcp
 npx @wong2/mcp-cli --sse http://localhost:8000/sse
 ```
 
+### Non-interactive mode
+
+Run a specific tool, resource, or prompt without interactive prompts:
+
+```bash
+npx @wong2/mcp-cli --config config.json <primitive-name> [arguments-json]
+```
+
+Examples:
+
+```bash
+# Call a tool with arguments
+npx @wong2/mcp-cli -c config.json filesystem/read_file '{"path": "package.json"}'
+
+# Call a tool without arguments
+npx @wong2/mcp-cli -c config.json list_files
+
+# Use a prompt
+npx @wong2/mcp-cli -c config.json create_summary '{"text": "Hello world"}'
+
+# Read a resource
+npx @wong2/mcp-cli -c config.json file://path/to/resource
+```
+
+This mode is useful for scripting and automation, as it bypasses all interactive prompts and executes the specified primitive directly.
+
 ### Purge stored data (OAuth tokens, etc.)
 
 ```bash

--- a/src/cli.js
+++ b/src/cli.js
@@ -14,6 +14,7 @@ const cli = meow(
     $ mcp-cli [--pass-env] node path/to/server/index.js args...
     $ mcp-cli --url http://localhost:8000/mcp
     $ mcp-cli --sse http://localhost:8000/sse
+    $ mcp-cli --config [config.json] <primitive-name> [arguments-json]
     $ mcp-cli purge
 
 	Options
@@ -39,13 +40,18 @@ const cli = meow(
 
 if (cli.input[0] === 'purge') {
   purge()
-} else if (cli.input.length > 0) {
-  const [command, ...args] = cli.input
-  await runWithCommand(command, args, cli.flags.passEnv ? process.env : undefined)
 } else if (cli.flags.url) {
   await runWithURL(cli.flags.url)
 } else if (cli.flags.sse) {
   await runWithSSE(cli.flags.sse)
+} else if (cli.flags.config && cli.input.length > 0) {
+  // Non-interactive mode: mcp-cli --config config.json primitive-name [args-json]
+  const [primitiveName, argsJson] = cli.input
+  const args = argsJson ? JSON.parse(argsJson) : {}
+  await runWithConfig(cli.flags.config, primitiveName, args)
+} else if (cli.input.length > 0) {
+  const [command, ...args] = cli.input
+  await runWithCommand(command, args, cli.flags.passEnv ? process.env : undefined)
 } else {
   await runWithConfig(cli.flags.config)
 }


### PR DESCRIPTION
Enables running specific tools, resources, or prompts directly from the command line without interactive prompts.

Usage:
mcp-cli --config config.json <primitive-name> [arguments-json]

This is useful for scripting and automation scenarios.