### PR TITLE
feat: Add support for resource-templates

### DIFF
--- a/package.json
+++ b/package.json
@@ -28,6 +28,7 @@
     "meow": "^13.2.0",
     "open": "^10.1.2",
     "prompts": "^2.4.2",
+    "uri-template": "^2.0.0",
     "yocto-spinner": "^0.2.2",
     "yoctocolors": "^2.1.1"
   }

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -38,6 +38,9 @@ importers:
       prompts:
         specifier: ^2.4.2
         version: 2.4.2
+      uri-template:
+        specifier: ^2.0.0
+        version: 2.0.0
       yocto-spinner:
         specifier: ^0.2.2
         version: 0.2.2
@@ -388,6 +391,9 @@ packages:
     resolution: {integrity: sha512-TdrF7fW9Rphjq4RjrW0Kp2AW0Ahwu9sRGTkS6bvDi0SCwZlEZYmcfDbEsTz8RVk0EHIS/Vd1bv3JhG+1xZuAyQ==, tarball: https://registry.npmjs.org/path-to-regexp/-/path-to-regexp-8.2.0.tgz}
     engines: {node: '>=16'}
 
+  pct-encode@1.0.3:
+    resolution: {integrity: sha512-+ojEvSHApoLWF2YYxwnOM4N9DPn5e5fG+j0YJ9drKNaYtrZYOq5M9ESOaBYqOHCXOAALODJJ4wkqHAXEuLpwMw==}
+
   pkce-challenge@5.0.0:
     resolution: {integrity: sha512-ueGLflrrnvwB3xuo/uGob5pd5FN7l0MsLf0Z87o/UQmRtwjvfylfc9MurIxRAWywCYTgrvpXBcqjV4OfCYGCIQ==, tarball: https://registry.npmjs.org/pkce-challenge/-/pkce-challenge-5.0.0.tgz}
     engines: {node: '>=16.20.0'}
@@ -503,6 +509,9 @@ packages:
   unpipe@1.0.0:
     resolution: {integrity: sha512-pjy2bYhSsufwWlKwPc+l3cN7+wuJlK6uz0YdJEOlQDbl6jo/YlPi4mb8agUkVC8BF7V8NuzeyPNqRksA3hztKQ==}
     engines: {node: '>= 0.8'}
+
+  uri-template@2.0.0:
+    resolution: {integrity: sha512-r/i44nPoo0ktEZDjx+hxp9PSjQuBBfsd6RgCRuuMqCP0FZEp+YE0SpihThI4UGc5ePqQEFsdyZc7UVlowp+LLw==}
 
   vary@1.1.2:
     resolution: {integrity: sha512-BNGbWLfd0eUPabhkXUVm0j8uuvREyTh5ovRa/dyow/BqAbZJyC+5fU+IzQOzmAKzYqYRAISoRhdQr3eIZ/PXqg==, tarball: https://registry.npmjs.org/vary/-/vary-1.1.2.tgz}
@@ -875,6 +884,8 @@ snapshots:
 
   path-to-regexp@8.2.0: {}
 
+  pct-encode@1.0.3: {}
+
   pkce-challenge@5.0.0: {}
 
   prompts@2.4.2:
@@ -1017,6 +1028,10 @@ snapshots:
   uint8array-extras@1.4.0: {}
 
   unpipe@1.0.0: {}
+
+  uri-template@2.0.0:
+    dependencies:
+      pct-encode: 1.0.3
 
   vary@1.1.2: {}
 


### PR DESCRIPTION
- [Resource templates](https://modelcontextprotocol.io/docs/concepts/resources#resource-templates) allow dynamic resources
- This commit includes:
  - reading resource-templates available on the server
  - letting the user type out the parts of the uri to expand the uri template
  - read the resource at the expanded uri