### PR TITLE
docs: add Fronteir AI hosted deployment option

### DIFF
--- a/README.md
+++ b/README.md
@@ -4,6 +4,10 @@ A CLI inspector for the Model Context Protocol
 
 https://github.com/user-attachments/assets/4cd113e9-f097-4c9d-b391-045c5f213183
 
+## Hosted deployment
+
+A hosted deployment is available on [Fronteir AI](https://fronteir.ai/mcp/wong2-mcp-cli).
+
 ## Features
 
 - Run MCP servers from various sources


### PR DESCRIPTION
Love the project!

Adds a short note in the README that a hosted deployment is available on [Fronteir AI](https://fronteir.ai/mcp/wong2-mcp-cli)