### PR TITLE
docs: mention --pass-env for stdio servers

### DIFF
--- a/README.md
+++ b/README.md
@@ -35,11 +35,15 @@ The config file has the same format as the Claude Desktop config file.
 npx @wong2/mcp-cli npx <package-name> <args>
 ```
 
+Add `--pass-env` if the server needs environment variables from your current shell.
+
 ### Run locally developed server
 
 ```bash
 npx @wong2/mcp-cli node path/to/server/index.js args...
 ```
+
+Add `--pass-env` if the server needs environment variables from your current shell.
 
 ### Connect to a running server over Streamable HTTP
 


### PR DESCRIPTION
## Summary
- document that `--pass-env` can be used when running stdio servers from npm or local node commands
- align README usage with the existing CLI help text

## Validation
- `git diff --check`

Note: dependency install was not run locally because `pnpm` is not installed and `corepack pnpm install --frozen-lockfile` failed with a Corepack keyid verification error on this machine.