### PR TITLE
Add npm repository and bugs metadata

### DIFF
--- a/package.json
+++ b/package.json
@@ -7,6 +7,13 @@
   },
   "type": "module",
   "homepage": "https://github.com/wong2/mcp-cli",
+  "repository": {
+    "type": "git",
+    "url": "git+https://github.com/wong2/mcp-cli.git"
+  },
+  "bugs": {
+    "url": "https://github.com/wong2/mcp-cli/issues"
+  },
   "files": [
     "src",
     "README.md"


### PR DESCRIPTION
## Summary

- add npm `repository` metadata pointing to this GitHub repo
- add `bugs.url` so npm users can find the issue tracker directly

## Why

The published `@wong2/mcp-cli@2.0.0` package currently exposes a homepage, but npm metadata does not include `repository` or `bugs`. Adding these standard fields improves npm discoverability and gives package users and tooling a direct source/issues link.

## Verification

- `node -e "const p=require('./package.json'); if(!p.repository?.url||!p.bugs?.url) process.exit(1); console.log(p.repository.url); console.log(p.bugs.url);"`
- `npm pack --dry-run`
- `git diff --check`