### PR TITLE
feat(cli): add non-interactive list-tools command

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,7 @@
+# 2.1.0
+
+- Add `list-tools` non-interactive command to list tools from a configured MCP server
+
 # 2.0.0
 
 - **Breaking**: require Node.js 20 or newer

--- a/README.md
+++ b/README.md
@@ -59,7 +59,7 @@ npx @wong2/mcp-cli --sse http://localhost:8000/sse
 
 ### Non-interactive mode
 
-Run a specific tool, resource, or prompt without interactive prompts:
+Run a specific tool, resource, or prompt without interactive prompts, or list tools from a configured server:
 
 ```bash
 npx @wong2/mcp-cli [--config config.json] <command> <server-name>:<target> [--args '{}']
@@ -70,6 +70,9 @@ Examples:
 ```bash
 # Call a tool without arguments
 npx @wong2/mcp-cli -c config.json call-tool filesystem:list_files
+
+# List tools exposed by a configured server
+npx @wong2/mcp-cli -c config.json list-tools filesystem
 
 # Call a tool with arguments
 npx @wong2/mcp-cli -c config.json call-tool filesystem:read_file --args '{"path": "package.json"}'

--- a/src/cli.js
+++ b/src/cli.js
@@ -15,6 +15,7 @@ const cli = meow(
     $ mcp-cli --url http://localhost:8000/mcp
     $ mcp-cli --sse http://localhost:8000/sse
     $ mcp-cli purge
+    $ mcp-cli [--config config.json] list-tools <server_name>
     $ mcp-cli [--config config.json] call-tool <server_name>:<tool_name> [--args '{"key":"value"}']
     $ mcp-cli [--config config.json] read-resource <server_name>:<resource_uri>
     $ mcp-cli [--config config.json] get-prompt <server_name>:<prompt_name> [--args '{"key":"value"}']
@@ -53,6 +54,9 @@ const options = { compact: cli.flags.compact }
 
 if (cli.input[0] === 'purge') {
   purge()
+} else if (cli.input.length >= 2 && cli.input[0] === 'list-tools') {
+  const [, serverName] = cli.input
+  await runWithConfigNonInteractive(cli.flags.config, serverName, 'list-tools')
 } else if (
   cli.input.length >= 2 &&
   (cli.input[0] === 'call-tool' || cli.input[0] === 'read-resource' || cli.input[0] === 'get-prompt')

--- a/src/mcp.js
+++ b/src/mcp.js
@@ -218,7 +218,9 @@ export async function runWithConfigNonInteractive(configPath, serverName, comman
       }
     }
 
-    if (command === 'call-tool') {
+    if (command === 'list-tools') {
+      result = await client.listTools()
+    } else if (command === 'call-tool') {
       result = await client.callTool({ name: target, arguments: args })
     } else if (command === 'read-resource') {
       result = await client.readResource({ uri: target })


### PR DESCRIPTION
## Summary

Add `list-tools <server_name>` for non-interactive discovery of MCP tools from a configured server.

Fixes #17

## Motivation

Scripting and automation workflows need a way to enumerate tools without entering the interactive inspector. Issue #17 requests a command alongside `call-tool` for this purpose.

## Changes

- Route `list-tools <server_name>` through the existing config-based non-interactive connection path
- Dispatch to `client.listTools()` and print JSON to stdout (same error handling as `call-tool`)
- Document usage in README and CHANGELOG

## Tests

- `node --check src/cli.js`
- `node --check src/mcp.js`

## Notes

- Stdio/config mode only, matching existing non-interactive commands (`call-tool`, `read-resource`, `get-prompt`)
- composer-2.5 review: APPROVE after consolidating into `runWithConfigNonInteractive`